### PR TITLE
Fix op() type

### DIFF
--- a/src/soap.hrl
+++ b/src/soap.hrl
@@ -32,7 +32,7 @@
                                                %% during construction of the 
                                                %% interface
     out_type :: [{string(), atom()}] | undefined | atom(), %% see above
-    fault_types :: [atom()]}).
+    fault_types :: [atom()] | undefined}).
 -type op() :: #op{}.
 
 -record(interface, {


### PR DESCRIPTION
This fixes almost all Dialyzer warnings in our code.